### PR TITLE
Lane visualization

### DIFF
--- a/rmf_schedule_visualizer/CMakeLists.txt
+++ b/rmf_schedule_visualizer/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(rmf_traffic_msgs)
 find_package(rosidl_default_generators REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(rmf_schedule_visualizer_msgs REQUIRED)
+find_package(building_map_msgs REQUIRED)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -72,6 +73,7 @@ target_link_libraries(rviz2
     Boost::random
     ${rmf_traffic_msgs_LIBRARIES}
     ${rmf_schedule_visualizer_msgs_LIBRARIES}
+    ${building_map_msgs_LIBRARIES}
 )
 
 target_include_directories(rviz2
@@ -82,6 +84,7 @@ target_include_directories(rviz2
     ${visualization_msgs_INCLUDE_DIRS}
     ${geometry_msgs_INCLUDE_DIRS}
     ${rmf_schedule_visualizer_msgs_INCLUDE_DIRS}
+    ${building_map_msgs_INCLUDE_DIRS}
 )
 
 #===============================================================================

--- a/rmf_schedule_visualizer/package.xml
+++ b/rmf_schedule_visualizer/package.xml
@@ -16,6 +16,7 @@
   <depend>geometry_msgs</depend>
   <depend>visualization_msgs</depend>
   <depend>rmf_schedule_visualizer_msgs</depend>
+  <depend>building_map_msgs</depend>
 
   
   <test_depend>ament_lint_auto</test_depend>

--- a/rmf_schedule_visualizer/src/main_rviz.cpp
+++ b/rmf_schedule_visualizer/src/main_rviz.cpp
@@ -469,7 +469,7 @@ private:
     Point p;
     p.x = tp[0];
     p.y = tp[1];
-    p.z = 0;
+    p.z = tp[2];
     return p;
   }
 

--- a/rmf_schedule_visualizer/src/main_rviz.cpp
+++ b/rmf_schedule_visualizer/src/main_rviz.cpp
@@ -261,8 +261,8 @@ private:
       node_marker.pose.orientation.w = 1;
 
       // Set the scale of the marker
-      node_marker.scale.x = 0.1;
-      node_marker.scale.y = 0.1;
+      node_marker.scale.x = 0.2;
+      node_marker.scale.y = 0.2;
       node_marker.scale.z = 1.0;
 
       // Set the color
@@ -283,18 +283,14 @@ private:
       // Marker for lanes
       Marker lane_marker = node_marker;
       node_marker.id = 2;
-      lane_marker.type = lane_marker.LINE_STRIP;
-      lane_marker.scale.x = 0.1;
+      lane_marker.type = lane_marker.LINE_LIST;
+      lane_marker.scale.x = 0.2;
       lane_marker.color.r = 1.0f;
       lane_marker.color.g = 1.0f;
       lane_marker.color.b = 0.0f;
       lane_marker.color.a = 0.5;
 
       // Add node locations to point list 
-      std::cout<<"Level name: "<<_level.name<<std::endl;
-      std::cout<<"Nav Graph size: "<<_level.nav_graphs.size()<<std::endl;
-      std::cout<<"Wall Graph vertices size: "<<_level.wall_graph.vertices.size()<<std::endl;
-
       for (const auto nav_graph : _level.nav_graphs)
       {
         for (const auto vertex : nav_graph.vertices)
@@ -302,7 +298,6 @@ private:
           node_marker.points.push_back(make_point({vertex.x, vertex.y, 0}));
           std::cout<<"Added X: "<<vertex.x<<" Y: "<<vertex.y<<std::endl;
         }
-
         // Adding lane markers
 
         for (const auto edge : nav_graph.edges)
@@ -315,11 +310,13 @@ private:
           lane_marker.points.push_back(make_point({n2.x, n2.y, 0}));
         }
       }
+
+      // debugging graph lane 
+
       // Markers for lane directionality 
 
       marker_array.markers.push_back(node_marker);
       marker_array.markers.push_back(lane_marker);
-      std::cout<<"Added map marker"<<std::endl;
     }
   }
 
@@ -418,7 +415,7 @@ private:
     marker_msg.pose.orientation.w = 1;
 
     // Set the scale of the marker
-    marker_msg.scale.x =  0.5;
+    marker_msg.scale.x =  0.2;
     marker_msg.scale.y =  1.0;
     marker_msg.scale.z = 1.0;
 

--- a/rmf_schedule_visualizer/src/main_rviz.cpp
+++ b/rmf_schedule_visualizer/src/main_rviz.cpp
@@ -163,9 +163,6 @@ public:
               + std::to_string(msg->levels.size()) + " level(s)");
           // Storing building map message 
           _map_msg = *msg;
-          std::cout<<"Level name: "<<msg->levels[0].name<<std::endl;
-          std::cout<<"Nav Graph size: "<<msg->levels[0].nav_graphs.size()<<std::endl;
-          std::cout<<"Wall Graph vertices size: "<<msg->levels[0].wall_graph.vertices.size()<<std::endl;
         },
         sub_map_opt);
   }
@@ -216,10 +213,8 @@ private:
           _marker_tracker.insert(element.id);
       }
     }
-    std::cout<<"Marker Array size before map: "<<marker_array.markers.size()<<std::endl;
     // Add map markers
     add_map_markers(marker_array);
-    std::cout<<"Marker Array size after map: "<<marker_array.markers.size()<<std::endl;
 
     // Add deletion markers for trajectories no longer active 
     std::unordered_set<uint64_t> removed_markers;
@@ -276,11 +271,23 @@ private:
       node_marker.color.b = 0.0f;
       node_marker.color.a = 1.0;
 
+      if (_rate <= 1)
+        node_marker.lifetime = convert(_timer_period);
+      else
+      {
+        builtin_interfaces::msg::Duration duration;
+        duration.sec = 1;
+        duration.nanosec = 0;
+        node_marker.lifetime = duration;
+      }
       // Marker for lanes
       Marker lane_marker = node_marker;
       lane_marker.type = lane_marker.LINE_STRIP;
-      lane_marker.scale.x = 2;
-      lane_marker.color.b = 0.5f;
+      lane_marker.scale.x = 0.1;
+      lane_marker.color.r = 1.0f;
+      lane_marker.color.g = 1.0f;
+      lane_marker.color.b = 0.0f;
+      lane_marker.color.a = 0.5;
 
       // Add node locations to point list 
       std::cout<<"Level name: "<<_level.name<<std::endl;
@@ -289,11 +296,11 @@ private:
 
       for (const auto nav_graph : _level.nav_graphs)
       {
-        for (const auto vertex : nav_graph.vertices)
-        {
-          node_marker.points.push_back(make_point({vertex.x, vertex.y, 0}));
-          std::cout<<"Added X: "<<vertex.x<<" Y: "<<vertex.y<<std::endl;
-        }
+        // for (const auto vertex : nav_graph.vertices)
+        // {
+        //   node_marker.points.push_back(make_point({vertex.x, vertex.y, 0}));
+        //   std::cout<<"Added X: "<<vertex.x<<" Y: "<<vertex.y<<std::endl;
+        // }
 
         // Adding lane markers
 
@@ -307,8 +314,8 @@ private:
       }
       // Markers for lane directionality 
 
-      marker_array.markers.push_back(node_marker);
-      // marker_array.markers.push_back(lane_marker);
+      // marker_array.markers.push_back(node_marker);
+      marker_array.markers.push_back(lane_marker);
       std::cout<<"Added map marker"<<std::endl;
     }
   }

--- a/rmf_schedule_visualizer/src/main_rviz.cpp
+++ b/rmf_schedule_visualizer/src/main_rviz.cpp
@@ -261,8 +261,8 @@ private:
       node_marker.pose.orientation.w = 1;
 
       // Set the scale of the marker
-      node_marker.scale.x = 1.0;
-      node_marker.scale.y = 1.0;
+      node_marker.scale.x = 0.1;
+      node_marker.scale.y = 0.1;
       node_marker.scale.z = 1.0;
 
       // Set the color
@@ -282,6 +282,7 @@ private:
       }
       // Marker for lanes
       Marker lane_marker = node_marker;
+      node_marker.id = 2;
       lane_marker.type = lane_marker.LINE_STRIP;
       lane_marker.scale.x = 0.1;
       lane_marker.color.r = 1.0f;
@@ -296,11 +297,11 @@ private:
 
       for (const auto nav_graph : _level.nav_graphs)
       {
-        // for (const auto vertex : nav_graph.vertices)
-        // {
-        //   node_marker.points.push_back(make_point({vertex.x, vertex.y, 0}));
-        //   std::cout<<"Added X: "<<vertex.x<<" Y: "<<vertex.y<<std::endl;
-        // }
+        for (const auto vertex : nav_graph.vertices)
+        {
+          node_marker.points.push_back(make_point({vertex.x, vertex.y, 0}));
+          std::cout<<"Added X: "<<vertex.x<<" Y: "<<vertex.y<<std::endl;
+        }
 
         // Adding lane markers
 
@@ -308,6 +309,8 @@ private:
         {
           auto n1 = nav_graph.vertices[edge.v1_idx];
           auto n2 = nav_graph.vertices[edge.v2_idx];
+          std::cout<<"Node 1 X: "<<n1.x<<" Y: "<<n1.y<<std::endl;
+          std::cout<<"Node 2 X: "<<n2.x<<" Y: "<<n2.y<<std::endl;
           lane_marker.points.push_back(make_point({n1.x, n1.y, 0}));
           lane_marker.points.push_back(make_point({n2.x, n2.y, 0}));
         }

--- a/rmf_schedule_visualizer/src/main_rviz.cpp
+++ b/rmf_schedule_visualizer/src/main_rviz.cpp
@@ -317,7 +317,7 @@ private:
       }
       // Markers for lane directionality 
 
-      // marker_array.markers.push_back(node_marker);
+      marker_array.markers.push_back(node_marker);
       marker_array.markers.push_back(lane_marker);
       std::cout<<"Added map marker"<<std::endl;
     }

--- a/rmf_schedule_visualizer/src/main_rviz.cpp
+++ b/rmf_schedule_visualizer/src/main_rviz.cpp
@@ -52,19 +52,19 @@ public:
       std::string node_name,
       rmf_schedule_visualizer::VisualizerDataNode& visualizer_data_node,
       std::string map_name,
-      double rate = 1,
+      double rate = 1.0,
       std::string frame_id = "/map")
   : Node(node_name),
     _visualizer_data_node(visualizer_data_node),
     _rate(rate),
     _frame_id(frame_id)
   {
-    // Initializing level 
+    // Initializing boolean to indicate whether level cache is relevant 
     _has_level = false;
 
     // TODO add a constructor for RvizParam
     _rviz_param.map_name = map_name;
-    _rviz_param.query_duration = std::chrono::seconds(60);
+    _rviz_param.query_duration = std::chrono::seconds(600);
     _rviz_param.start_duration = std::chrono::seconds(0);
 
     // Creating a timer with specified rate. This timer runs on the main thread.
@@ -266,8 +266,8 @@ private:
       node_marker.pose.orientation.w = 1;
 
       // Set the scale of the marker
-      node_marker.scale.x = 100;
-      node_marker.scale.y = 100;
+      node_marker.scale.x = 1.0;
+      node_marker.scale.y = 1.0;
       node_marker.scale.z = 1.0;
 
       // Set the color
@@ -280,7 +280,7 @@ private:
       Marker lane_marker = node_marker;
       lane_marker.type = lane_marker.LINE_STRIP;
       lane_marker.scale.x = 2;
-
+      lane_marker.color.b = 0.5f;
 
       // Add node locations to point list 
       std::cout<<"Level name: "<<_level.name<<std::endl;
@@ -528,7 +528,6 @@ private:
   };
 
   double _rate;
-  int _count;
   std::string _frame_id;
   std::vector<int64_t> _conflict_id;
   std::unordered_set<uint64_t> _marker_tracker; 

--- a/rmf_schedule_visualizer/src/main_rviz.cpp
+++ b/rmf_schedule_visualizer/src/main_rviz.cpp
@@ -173,7 +173,7 @@ public:
         sub_map_opt);
     
     // set the color list used to assign colors to graphs and robots
-    set_color_list();
+    set_color_list(0.3);
   }
 
 private:
@@ -270,12 +270,12 @@ private:
       node_marker.pose.orientation.w = 1;
 
       // Set the scale of the marker
-      node_marker.scale.x = 0.2;
-      node_marker.scale.y = 0.2;
+      node_marker.scale.x = 0.1;
+      node_marker.scale.y = 0.1;
       node_marker.scale.z = 1.0;
 
       // Set the color
-      node_marker.color = make_color(0.8, 1.0, 0.2);
+      node_marker.color = make_color(1, 1, 1);
 
       if (_rate <= 1)
         node_marker.lifetime = convert(_timer_period);
@@ -290,7 +290,7 @@ private:
       Marker lane_marker = node_marker;
       lane_marker.id = 2;
       lane_marker.type = lane_marker.LINE_LIST;
-      lane_marker.scale.x = 0.2;
+      lane_marker.scale.x = 0.5;
 
       // Add markers for nodes and lanes in each graph
       uint64_t graph_count = 0;
@@ -309,8 +309,8 @@ private:
         {
           auto n1 = nav_graph.vertices[edge.v1_idx];
           auto n2 = nav_graph.vertices[edge.v2_idx];
-          lane_marker.points.push_back(make_point({n1.x, n1.y, 0}));
-          lane_marker.points.push_back(make_point({n2.x, n2.y, 0}));
+          lane_marker.points.push_back(make_point({n1.x, n1.y, -0.2}));
+          lane_marker.points.push_back(make_point({n2.x, n2.y, -0.2}));
         }
         graph_count++;
         // Insert lane marker to marker_array
@@ -526,18 +526,18 @@ private:
     return color;
   }
 
-  void set_color_list()
+  void set_color_list(float alpha = 1)
   { 
     // List of colors that will be paired with graph ids.
     // Add additional colors here.
     // orange
-    _color_list.push_back(make_color(0.99, 0.5, 0.19, 0.5));
+    _color_list.push_back(make_color(0.99, 0.5, 0.19, alpha));
     // blue
-    _color_list.push_back(make_color(0, 0.5, 0.8, 0.5));     
+    _color_list.push_back(make_color(0, 0.5, 0.8, alpha));     
     // purple 
-    _color_list.push_back(make_color(0.57, 0.12, 0.7, 0.5));
+    _color_list.push_back(make_color(0.57, 0.12, 0.7, alpha));
     // cyan    
-    _color_list.push_back(make_color(0.27, 0.94, 0.94, 0.5));
+    _color_list.push_back(make_color(0.27, 0.94, 0.94, alpha));
   }
 
   Color get_color(uint64_t id)

--- a/rmf_schedule_visualizer/src/main_rviz.cpp
+++ b/rmf_schedule_visualizer/src/main_rviz.cpp
@@ -309,8 +309,8 @@ private:
         {
           auto n1 = nav_graph.vertices[edge.v1_idx];
           auto n2 = nav_graph.vertices[edge.v2_idx];
-          lane_marker.points.push_back(make_point({n1.x, n1.y, -0.2}));
-          lane_marker.points.push_back(make_point({n2.x, n2.y, -0.2}));
+          lane_marker.points.push_back(make_point({n1.x, n1.y, -0.2}, true));
+          lane_marker.points.push_back(make_point({n2.x, n2.y, -0.2}, true));
         }
         graph_count++;
         // Insert lane marker to marker_array
@@ -412,17 +412,15 @@ private:
 
     // Set the scale of the marker
     marker_msg.scale.x =  0.2;
-    marker_msg.scale.y =  1.0;
-    marker_msg.scale.z = 1.0;
 
     // Set the color
     if (conflict)
     {
-      marker_msg.color = make_color(1.0, 0, 0, 0.5);
+      marker_msg.color = make_color(1.0, 0, 0, 0.7);
     }
     else
     {
-      marker_msg.color = make_color(0.0, 1.0, 0, 0.5);
+      marker_msg.color = make_color(0.0, 1.0, 0, 0.7);
     }
     
     if (_rate <= 1)
@@ -464,12 +462,12 @@ private:
     return marker_msg;
   }
 
-  Point make_point(const Eigen::Vector3d tp)
+  Point make_point(const Eigen::Vector3d tp, bool z = false)
   {
     Point p;
     p.x = tp[0];
     p.y = tp[1];
-    p.z = tp[2];
+    p.z = z ? tp[2] : 0;
     return p;
   }
 
@@ -536,8 +534,18 @@ private:
     _color_list.push_back(make_color(0, 0.5, 0.8, alpha));     
     // purple 
     _color_list.push_back(make_color(0.57, 0.12, 0.7, alpha));
+    // teal
+    _color_list.push_back(make_color(0, 0.5, 0.5, alpha));
+    // lavender 
+    _color_list.push_back(make_color(0.9, 0.74, 1.0, alpha));
+    // olive
+    _color_list.push_back(make_color(0.5, 0.5, 0, alpha));
     // cyan    
     _color_list.push_back(make_color(0.27, 0.94, 0.94, alpha));
+    // grey
+    _color_list.push_back(make_color(0.5, 0.5, 0.5, alpha));
+    // maroon
+    _color_list.push_back(make_color(0.5, 0, 0, alpha));
   }
 
   Color get_color(uint64_t id)

--- a/rmf_schedule_visualizer/src/main_rviz.cpp
+++ b/rmf_schedule_visualizer/src/main_rviz.cpp
@@ -28,6 +28,7 @@
 #include <visualization_msgs/msg/marker.hpp>
 #include <rmf_traffic_msgs/msg/schedule_conflict.hpp>
 #include "rmf_schedule_visualizer_msgs/msg/rviz_param.hpp"
+#include <building_map_msgs/msg/building_map.hpp>
 
 #include <mutex>
 

--- a/rmf_schedule_visualizer/src/main_rviz.cpp
+++ b/rmf_schedule_visualizer/src/main_rviz.cpp
@@ -63,7 +63,7 @@ public:
     _rviz_param.query_duration = std::chrono::seconds(60);
     _rviz_param.start_duration = std::chrono::seconds(0);
 
-    // creating a timer with specified rate. This timer runs on the main thread.
+    // Creating a timer with specified rate. This timer runs on the main thread.
     int64_t s = 1/ _rate ;
     auto sec = std::chrono::seconds(s);
     _timer_period = std::chrono::duration_cast<std::chrono::nanoseconds>(sec);
@@ -71,12 +71,12 @@ public:
         _timer_period,
         std::bind(&RvizNode::timer_callback, this));
 
-    // creating publisher for marker_array
+    // Creating publisher for marker_array
     _marker_array_pub = this->create_publisher<MarkerArray>(
         "dp2_marker_array",
         rclcpp::SystemDefaultsQoS());
     
-    // creating subscriber for schedule_conflict in separate threead
+    // Creating subscriber for schedule_conflict in separate threead
     _cb_group_conflict_sub = this->create_callback_group(
         rclcpp::callback_group::CallbackGroupType::MutuallyExclusive);
     auto sub_conflict_opt = rclcpp::SubscriptionOptions();
@@ -93,7 +93,7 @@ public:
           },
           sub_conflict_opt);
 
-    // creating subscriber for rviz_param in separate thread
+    // Creating subscriber for rviz_param in separate thread
     _cb_group_param_sub = this->create_callback_group(
         rclcpp::callback_group::CallbackGroupType::MutuallyExclusive);
     auto sub_param_opt = rclcpp::SubscriptionOptions();
@@ -115,12 +115,12 @@ public:
           },
           sub_param_opt);
     
-    // creating subcscriber for building_map in separate thread
+    // Creating subcscriber for building_map in separate thread.
+    // The subscriber requies QoS profile with transient local durability
     _cb_group_map_sub = this->create_callback_group(
     rclcpp::callback_group::CallbackGroupType::MutuallyExclusive);
     auto sub_map_opt = rclcpp::SubscriptionOptions();
     sub_map_opt.callback_group = _cb_group_map_sub;
-    // /map topic requies QoS profile with transient local durability
     auto qos_profile = rclcpp::QoS(10);
     qos_profile.transient_local();
     _map_sub = this->create_subscription<BuildingMap>(
@@ -150,7 +150,6 @@ private:
     query_param.finish_time = query_param.start_time + _rviz_param.query_duration;
 
     _elements = _visualizer_data_node.get_elements(query_param);
-    // std::cout<<"Element size: "<<_elements.size()<<std::endl;
 
     RequestParam traj_param;
     traj_param.map_name = query_param.map_name;
@@ -160,12 +159,12 @@ private:
     // store the ids of active trajectories
     std::vector<uint64_t> active_id;
 
-    // for each trajectory create two markers
+    // For each trajectory create two markers
     // 1) Current position 
     // 2) Path until param.finish_time
     for (const auto& element : _elements)
     {
-      // create markers for trajectories that are active within time range
+      // Create markers for trajectories that are active within time range
       if (element.trajectory.find(traj_param.start_time) != element.trajectory.end())
       {
         active_id.push_back(element.id);
@@ -176,13 +175,13 @@ private:
         auto path_marker = make_path_marker(element, traj_param);
         marker_array.markers.push_back(path_marker);
 
-        // adding to id to _marker_tracker 
+        // Adding to id to _marker_tracker 
         if (_marker_tracker.find(element.id) == _marker_tracker.end())
           _marker_tracker.insert(element.id);
       }
     }
     
-    // add deletion markers for trajectories no longer active 
+    // Add deletion markers for trajectories no longer active 
     std::unordered_set<uint64_t> removed_markers;
     for (const auto marker : _marker_tracker)
     {


### PR DESCRIPTION
This branch introduces two features:
* The visualizer subscribes to /map topic published by build_map_server node and displays color coded nodes and lanes present in each graph in the BuildingMap msg, if available.
* The trajectory path is now rendered until min(trajectory duration, query_duration)