### PR TITLE
Feature/waypoint names

### DIFF
--- a/rmf_schedule_visualizer/config/rmf.rviz
+++ b/rmf_schedule_visualizer/config/rmf.rviz
@@ -4,7 +4,8 @@ Panels:
     Name: Displays
     Property Tree Widget:
       Expanded:
-        - /MarkerArray2/Topic1
+        - /MarkerArray2
+        - /MarkerArray2/Namespaces1
       Splitter Ratio: 0.5
     Tree Height: 923
   - Class: rviz_common/Selection
@@ -51,13 +52,26 @@ Visualization Manager:
       Enabled: true
       Name: MarkerArray
       Namespaces:
-        map: true
+        {}
       Topic:
         Depth: 5
         Durability Policy: Volatile
         History Policy: Keep Last
         Reliability Policy: Reliable
-        Value: dp2_marker_array
+        Value: /schedule_markers
+      Value: true
+    - Class: rviz_default_plugins/MarkerArray
+      Enabled: true
+      Name: MarkerArray
+      Namespaces:
+        labels: false
+        map: true
+      Topic:
+        Depth: 5
+        Durability Policy: Transient Local
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /map_markers
       Value: true
     - Class: rviz_default_plugins/MarkerArray
       Enabled: true
@@ -135,11 +149,11 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Scale: 81.27279663085938
+      Scale: 79.88577270507812
       Target Frame: <Fixed Frame>
       Value: TopDownOrtho (rviz_default_plugins)
-      X: 17.417360305786133
-      Y: -21.619190216064453
+      X: 16.866823196411133
+      Y: -21.146560668945312
     Saved: ~
 Window Geometry:
   Displays:

--- a/rmf_schedule_visualizer/src/main_rviz.cpp
+++ b/rmf_schedule_visualizer/src/main_rviz.cpp
@@ -272,8 +272,8 @@ private:
 
       // Set the pose of the marker
       label_marker.pose.orientation.w = 1;
-      label_marker.pose.position.x = node.x + 1.2 * std::cos(0.7853);
-      label_marker.pose.position.y = node.y + 1.2 * std::sin(0.7853);
+      label_marker.pose.position.x = node.x + 1.0 * std::cos(0.7853);
+      label_marker.pose.position.y = node.y + 1.0 * std::sin(0.7853);
       label_marker.pose.position.z = 0.0;
 
       // Set the scale of the marker
@@ -339,15 +339,10 @@ private:
       node_marker.id = 0;
       node_marker.type = node_marker.POINTS;
       node_marker.action = node_marker.MODIFY;
-
       node_marker.pose.orientation.w = 1;
-
-      // Set the scale of the marker
       node_marker.scale.x = 0.1;
       node_marker.scale.y = 0.1;
       node_marker.scale.z = 1.0;
-
-      // Set the color of the marker
       node_marker.color = make_color(1, 1, 1);
 
       // Marker for lanes
@@ -660,7 +655,6 @@ private:
           _has_level = true;
           _level = level;
           RCLCPP_INFO(this->get_logger(),"Level cache updated");
-          // publish_map_markers();
           break;
         }
       }
@@ -668,10 +662,10 @@ private:
       if (!_has_level)
       {
         RCLCPP_INFO(this->get_logger(),"Level cache not updated");
-        // publish_map_markers(true);
       }
 
       publish_map_markers();
+      
     }
   }
 


### PR DESCRIPTION
This PR accomplishes two tasks:
1. Publish names of waypoints as text markers
2. Improve visualizer efficiency by splitting the `/dp2_marker_array` topic into a) `/schedule_markers` for active trajectories and b) `/map_markers` for graph nodes, lanes and waypoint names. The later topic has durability `transient local` and a `MarkerArray msg` is only published when a new `Map Name` is queried through the `Schedule Panel`, thus saving bandwidth.

This update requires modification to existing rviz config files. Namely to replace the old `/dp2_marker_array` topic visualization with `/schedule_markers` and `/map_markers`. By default, the Durability Policy for `/map_markers` is `Volatile` and requires to be set to `Transient Local`. 

If the waypoint names visualization is not desirable, the `labels` namespace under `/map_markers Namespaces` may be unchecked. 

Saving the new config and re-launching the visualization will render the desired view.

![image](https://user-images.githubusercontent.com/13482049/76589815-417b8c80-6526-11ea-827a-1a7941ebf3b9.png)
