### PR TITLE
Trajectory requests accepts a trim parameter

### DIFF
--- a/rmf_schedule_visualizer/src/Server.cpp
+++ b/rmf_schedule_visualizer/src/Server.cpp
@@ -245,7 +245,6 @@ std::string Server::parse_trajectories(
         }
 
         // Add the trimmed end
-        ++it;
         assert(it != trajectory.end());
         motion = it->compute_motion();
         add_segment(end_time,

--- a/rmf_schedule_visualizer/src/Server.cpp
+++ b/rmf_schedule_visualizer/src/Server.cpp
@@ -248,9 +248,9 @@ std::string Server::parse_trajectories(
         ++it;
         assert(it != trajectory.end());
         motion = it->compute_motion();
-        add_segment(start_time,
-            motion->compute_position(start_time),
-            motion->compute_velocity(start_time));
+        add_segment(end_time,
+            motion->compute_position(end_time),
+            motion->compute_velocity(end_time));
       }
 
       else

--- a/rmf_schedule_visualizer/src/Server.hpp
+++ b/rmf_schedule_visualizer/src/Server.hpp
@@ -86,7 +86,10 @@ private:
 
   bool parse_request(const server::message_ptr msg, std::string& response);
 
-  std::string parse_trajectories(const std::vector<Element>& elements);
+  std::string parse_trajectories(
+      const std::vector<Element>& elements,
+      const bool trim,
+      const RequestParam& request_param);
 
   server _server;
   con_list _connections;


### PR DESCRIPTION
Added `trim` to list of parameters in a `trajectory` websocket request.
Eg:
```
{"request":"trajectory","param":{"map_name":"L1","duration":10, "trim":true}}
```
will trim the ends of the trajectories that overlap with the query period