### PR TITLE
Webserver response with schedule conflict data

### DIFF
--- a/rmf_schedule_visualizer/src/Server.cpp
+++ b/rmf_schedule_visualizer/src/Server.cpp
@@ -192,6 +192,7 @@ std::string Server::parse_trajectories(
   std::string response;
   auto j_res = _j_res;
   j_res["response"] = "trajectory";
+  j_res["conflicts"] = _visualizer_data_node.get_conflicts();
 
   try
   {

--- a/rmf_schedule_visualizer/src/Server.hpp
+++ b/rmf_schedule_visualizer/src/Server.hpp
@@ -100,7 +100,7 @@ private:
   std::unique_ptr<Data> data;
 
     // Templates used for response generation
-  const json _j_res = { {"response", {}}, {"values", {}}};
+  const json _j_res = { {"response", {}}, {"values", {}}, {"conflicts", {}}};
   const json _j_traj ={ {"id", {}}, {"shape", {}}, {"dimensions", {}}, {"segments", {}}};
   const json _j_seg = { {"x", {}}, {"v", {}}, {"t", {}}};
 };

--- a/rmf_schedule_visualizer/src/VisualizerData.cpp
+++ b/rmf_schedule_visualizer/src/VisualizerData.cpp
@@ -92,7 +92,7 @@ void VisualizerDataNode::start(Data _data)
       std::lock_guard<std::mutex> lock(_mutex);
       _conflict_id.clear();
       for (const auto& i : msg->indices)
-        _conflict_id.push_back(i);
+        _conflict_id.insert(i);
     });
 }
 
@@ -191,7 +191,7 @@ std::mutex& VisualizerDataNode::get_mutex()
   return _mutex;
 }
 
-std::vector<uint64_t> VisualizerDataNode::get_conflicts() const
+const std::unordered_set<uint64_t>& VisualizerDataNode::get_conflicts() const
 {
   return _conflict_id;
 }

--- a/rmf_schedule_visualizer/src/VisualizerData.hpp
+++ b/rmf_schedule_visualizer/src/VisualizerData.hpp
@@ -29,6 +29,7 @@
 #include <rclcpp/node.hpp>
 
 #include <std_msgs/msg/string.hpp>
+#include <rmf_traffic_msgs/msg/schedule_conflict.hpp>
 
 #include <websocketpp/config/asio_no_tls.hpp>
 #include <websocketpp/server.hpp>
@@ -42,6 +43,8 @@ class VisualizerDataNode : public rclcpp::Node
 {
 public:
   using Element = rmf_traffic::schedule::Viewer::View::Element;
+  using ScheduleConflict = rmf_traffic_msgs::msg::ScheduleConflict;
+
   /// Builder function which returns a pointer to VisualizerNode when
   /// the Mirror Manager is readied and websocket is started.
   /// A nullptr is returned if initialization fails. 
@@ -55,6 +58,8 @@ public:
   /// Function to query Mirror Manager for elements containing
   /// trajectory and ID pairs.
   std::vector<Element> get_elements(RequestParam request_param);
+
+  std::vector<uint64_t> get_conflicts() const;
 
   rmf_traffic::Time now();
 
@@ -77,15 +82,17 @@ private:
 
   void debug_cb(std_msgs::msg::String::UniquePtr msg);
 
+  void start(Data data);
+
   using DebugSub = rclcpp::Subscription<std_msgs::msg::String>;
   DebugSub::SharedPtr debug_sub;
-
-  void start(Data data);
+  rclcpp::Subscription<ScheduleConflict>::SharedPtr _conflcit_sub;
 
   std::vector<rmf_traffic::Trajectory> _trajectories;
   std::string _node_name;
   std::unique_ptr<Data> data;
   std::mutex _mutex;
+  std::vector<uint64_t> _conflict_id;
 };
 
 } // namespace rmf_schedule_visualizer

--- a/rmf_schedule_visualizer/src/VisualizerData.hpp
+++ b/rmf_schedule_visualizer/src/VisualizerData.hpp
@@ -36,6 +36,7 @@
 
 #include <set>
 #include <mutex>
+#include <unordered_set>
 
 namespace rmf_schedule_visualizer {
 
@@ -59,7 +60,7 @@ public:
   /// trajectory and ID pairs.
   std::vector<Element> get_elements(RequestParam request_param);
 
-  std::vector<uint64_t> get_conflicts() const;
+  const std::unordered_set<uint64_t>& get_conflicts() const;
 
   rmf_traffic::Time now();
 
@@ -92,7 +93,7 @@ private:
   std::string _node_name;
   std::unique_ptr<Data> data;
   std::mutex _mutex;
-  std::vector<uint64_t> _conflict_id;
+  std::unordered_set<uint64_t> _conflict_id;
 };
 
 } // namespace rmf_schedule_visualizer


### PR DESCRIPTION
This PR adds a `conflicts` field to the server response for a `trajectory` request. The field is populated with the `id` of trajectories that are currently in conflict. 

Request:
```
{"request":"trajectory","param":{"map_name":"L1","duration":60000, "trim":true}}
```

Response:
```
{"response":"trajectory", "values": [...], "conflicts": []}
```
