### PR TITLE
Added type to a param to fix Frontend build error

### DIFF
--- a/frontend/src/components/schedule-visualizer/index.tsx
+++ b/frontend/src/components/schedule-visualizer/index.tsx
@@ -67,7 +67,7 @@ export default function ScheduleVisualizer() {
 
   React.useEffect(() => {
     getFloors().then((floors) => {
-      setFloors(produce<_IFloor[], any, IFloor[]>(floors, (draft) => {
+      setFloors(produce<_IFloor[], any, IFloor[]>(floors, (draft:any) => {
         for (const floor of draft) {
           const { elevation, image } = floor
           const { pose, scale } = image


### PR DESCRIPTION
### Problem
I got this error when I tried to do a `yarn start` or `yarn build `

```
Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade`
Failed to compile.
```

```
/../rmf_schedule_visualizer/frontend/src/components/schedule-visualizer/index.tsx
TypeScript error in /../rmf_schedule_visualizer/frontend/src/components/schedule-visualizer/index.tsx(70,60):
Parameter 'draft' implicitly has an 'any' type.  TS7006
```
### Observation 
I know this is not a good solution, but at least is a start.  :)