### PR TITLE
Fix rosdep websocketpp error

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
     - name: deps
       run: |
         sudo apt update
-        sudo apt-get install libwebsocketpp-dev python3-shapely python3-yaml \
+        sudo apt-get install python3-shapely python3-yaml \
         libboost-system-dev libboost-date-time-dev libboost-regex-dev libboost-random-dev -y
     - name: setup
       run: |
@@ -30,8 +30,7 @@ jobs:
       run: |
         cd /home/ws_rmf
         rosdep update
-        rosdep install --from-paths src --ignore-src --rosdistro eloquent \
-          -y --skip-keys "websocketpp ament_python"
+        rosdep install --from-paths src --ignore-src --rosdistro eloquent -y
     - name: build
       shell: bash
       run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
         cd ws_rmf/src
         git clone https://github.com/osrf/traffic_editor
         git clone https://github.com/osrf/rmf_core
-        git clone https://github.com/osrf/rmf_schedule_visualizer
+        git clone https://github.com/"${GITHUB_REPOSITORY}"
         
     - name: checkout
       shell: bash

--- a/rmf_schedule_visualizer/package.xml
+++ b/rmf_schedule_visualizer/package.xml
@@ -12,7 +12,7 @@
   <depend>rmf_traffic</depend>
   <depend>rmf_traffic_ros2</depend>
   <depend>rclcpp</depend>
-  <depend>websocketpp</depend>
+  <depend>libwebsocketpp-dev</depend>
   <depend>geometry_msgs</depend>
   <depend>visualization_msgs</depend>
   <depend>rmf_schedule_visualizer_msgs</depend>


### PR DESCRIPTION
A simple fix for rosdep websocketpp not found

https://github.com/ros/rosdistro/pull/20339 has already added the websocketpp for `rosdep`

**P.S.** This Github Action config just don't work for forks:( because of this.
https://github.com/osrf/rmf_schedule_visualizer/blob/7292b256ed0fa866c0037914c20ac4aedd476405/.github/workflows/build.yaml#L22

So I added a simple fix here for the CI as well.

---

Edit: 
I cannot seem to PR on the `develop` branch, 
the build is failing at the moment and has conflict with master.