### PR TITLE
Install scripts properly in symlink installs

### DIFF
--- a/fleet_state_visualizer/setup.cfg
+++ b/fleet_state_visualizer/setup.cfg
@@ -1,2 +1,4 @@
+[develop]
+script-dir=$base/lib/fleet_state_visualizer
 [install]
 install-scripts=$base/lib/fleet_state_visualizer


### PR DESCRIPTION
When using `colcon build --symlink-install`, the installation method used for Python packages is different. It uses `python setup.py develop` instead of `python setup.py install` (see https://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode). This requires a separate section in the `setup.cfg` file. Without it, the scripts get copied to the `<install-prefix>/bin` directory instead of `<install-prefix>/lib/<pkgname>`. They can be executed directly but will not work with `ros2 run`.

The fix is to add a `develop` section to `setup.cfg` that specifies where scripts should be linked to when installing in development mode. [See here](https://github.com/ros2/examples/blob/a75151ef1388b565268508228df42c06462c1337/rclpy/topics/minimal_publisher/setup.cfg) for an example.