### PR TITLE
Improve lift and door marker display for multi-level nav-graphs

### DIFF
--- a/building_systems_visualizer/building_systems_visualizer/building_systems_visualizer.py
+++ b/building_systems_visualizer/building_systems_visualizer/building_systems_visualizer.py
@@ -324,7 +324,7 @@ class BuildingSystemsVisualizer(Node):
         self.active_markers = {}
         self.marker_pub.publish(marker_array)
 
-        # clearing door states and lift states to that markers can be updated
+        # clearing door states and lift states so that markers can be updated
         self.door_states[self.map_name] = {}
         self.lift_states = {}
 

--- a/building_systems_visualizer/package.xml
+++ b/building_systems_visualizer/package.xml
@@ -11,7 +11,7 @@
   <depend>rmf_door_msgs</depend>
   <depend>building_map_msgs</depend>
   <depend>geometry_msgs</depend>
-
+  <depend>rmf_schedule_visualizer_msgs</depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/fleet_state_visualizer/package.xml
+++ b/fleet_state_visualizer/package.xml
@@ -14,6 +14,8 @@
   <exec_depend>rmf_traffic_msgs</exec_depend>
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>visualization_msgs</exec_depend>
+  <exec_depend>building_map_msgs</exec_depend>
+  <exec_depend>rmf_schedule_visualizer_msgs</exec_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/rmf_schedule_visualizer/src/main_rviz.cpp
+++ b/rmf_schedule_visualizer/src/main_rviz.cpp
@@ -699,6 +699,7 @@ private:
           _has_level = true;
           _level = level;
           RCLCPP_INFO(this->get_logger(), "Level cache updated");
+          publish_map_markers();
           break;
         }
       }
@@ -707,9 +708,6 @@ private:
       {
         RCLCPP_INFO(this->get_logger(), "Level cache not updated");
       }
-
-      publish_map_markers();
-
     }
   }
 

--- a/visualizer/launch/visualizer.xml
+++ b/visualizer/launch/visualizer.xml
@@ -13,7 +13,7 @@
     <param name="use_sim_time" value="$(var use_sim_time)"/>
   </node>
 
-  <node pkg="fleet_state_visualizer" exec="fleet_state_visualizer">
+  <node pkg="fleet_state_visualizer" exec="fleet_state_visualizer" args="-m $(var map_name)">
     <param name="display_names" value ="$(var display_names)"/>
   </node>
 

--- a/visualizer/launch/visualizer.xml
+++ b/visualizer/launch/visualizer.xml
@@ -17,7 +17,7 @@
     <param name="display_names" value ="$(var display_names)"/>
   </node>
 
-  <node pkg="building_systems_visualizer" exec="building_systems_visualizer">
+  <node pkg="building_systems_visualizer" exec="building_systems_visualizer" args="-m $(var map_name)">
     <param name="use_sim_time" value="$(var use_sim_time)"/>
   </node>
 


### PR DESCRIPTION
This PR improves the lift and door marker display for multi-level nav-graphs. For door markers, only doors on the current floor being monitored will be shown. Lift markers' color scheme has been changed and uses green and blue to represent open and not open lift cabins. The lift markers will appear transparent when the corresponding cabins are moving or not on the currently monitored floor.