### PR TITLE
Fix the radius of rviz cylinder markers

### DIFF
--- a/rmf_schedule_visualizer/src/main_rviz.cpp
+++ b/rmf_schedule_visualizer/src/main_rviz.cpp
@@ -427,8 +427,8 @@ private:
     marker_msg.pose.orientation.w = quat.w;
 
     // Set the scale of the marker
-    marker_msg.scale.x = radius / 1.0;
-    marker_msg.scale.y = radius / 1.0;
+    marker_msg.scale.x = 2.0 * radius;
+    marker_msg.scale.y = 2.0 * radius;
     marker_msg.scale.z = height;
 
     // Set the color of the marker


### PR DESCRIPTION
It seems the rviz cylinder message expects `scale.x` and `scale.y` to refer to the cylinder's length all the way across, but we've been treating it as a radius value. This PR fixes that to provide a more accurate visualization of the vehicle profiles.