### PR TITLE
Add first pass of quality declarations for all packages

### DIFF
--- a/building_systems_visualizer/QUALITY_DECLARATION.md
+++ b/building_systems_visualizer/QUALITY_DECLARATION.md
@@ -1,0 +1,157 @@
+This document is a declaration of software quality for the `building_systems_visualizer` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `building_systems_visualizer` Quality Declaration
+
+The package `building_systems_visualizer` claims to be in the **Quality Level 4** category.
+
+Below are the detailed rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`building_systems_visualizer` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`building_systems_visualizer` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+`building_systems_visualizer` does not have a public API.
+
+### API Stability Policy [1.iv]
+
+`building_systems_visualizer` does not have a public API.
+
+### ABI Stability Policy [1.v]
+
+`building_systems_visualizer` does not have a public API.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`building_systems_visualizer` does not have a public API.
+
+## Change Control Process [2]
+
+`building_systems_visualizer` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`building_systems_visualizer` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`building_systems_visualizer` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+The CI checks only that the package builds.
+The most recent CI results can be seen on [the workflow page](https://github.com/osrf/rmf_schedule_visualizer/actions).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`building_systems_visualizer` is documented in the [parent repository's README.md file](https://github.com/osrf/rmf_schedule_visualizer/blob/master/README.md).
+
+### Public API Documentation [3.ii]
+
+`building_systems_visualizer` does not have a public API.
+
+### License [3.iii]
+
+The license for `building_systems_visualizer` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+### Copyright Statement [3.iv]
+
+The copyright holders each provide a statement of copyright in each source code file in `building_systems_visualizer`.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 4 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`building_systems_visualizer` does not have any tests.
+
+### Public API Testing [4.ii]
+
+`building_systems_visualizer` does not have a public API.
+
+### Coverage [4.iii]
+
+`building_systems_visualizer` does not track coverage statistics.
+
+### Performance [4.iv]
+
+`building_systems_visualizer` does not have performance tests.
+
+### Linters and Static Analysis [4.v]
+
+`building_systems_visualizer` uses the following linters:
+
+- Copyright
+- flake8
+- pep257
+
+The linters are not run automatically.
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`building_systems_visualizer` has the following direct runtime ROS dependencies.
+
+#### rmf\_lift\_msgs
+
+`rmf_lift_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_lift_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_door\_msgs
+
+`rmf_door_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_door_msgs/QUALITY_DECLARATION.md).
+
+#### building_map_msgs
+
+`building_map_msgs` is [**Quality Level 3**](https://github.com/osrf/traffic_editor/blob/master/building_map_msgs/QUALITY_DECLARATION.md).
+
+#### geometry_msgs
+
+`geometry_msgs` is [**Quality Level 3**](https://github.com/ros2/common_interfaces/blob/master/geometry_msgs/QUALITY_DECLARATION.md).
+
+#### rmf_schedule_visualizer_msgs
+
+`rmf_schedule_visualizer_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_schedule_visualizer/blob/master/rmf_schedule_visualizer_msgs/QUALITY_DECLARATION.md).
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`building_systems_visualizer` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`building_systems_visualizer` does not have any direct runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+`building_systems_visualizer` does not support all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers).
+`building_systems_visualizer` supports ROS Eloquent and ROS Foxy.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/building_systems_visualizer/README.md
+++ b/building_systems_visualizer/README.md
@@ -1,0 +1,7 @@
+# building\_systems\_visualizer
+
+This package provides visualisations for building infrastructure, such as doors and lifts.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.

--- a/building_systems_visualizer/building_systems_visualizer/building_systems_visualizer.py
+++ b/building_systems_visualizer/building_systems_visualizer/building_systems_visualizer.py
@@ -1,3 +1,17 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import rclpy
 from rclpy.node import Node
 

--- a/fleet_state_visualizer/QUALITY_DECLARATION.md
+++ b/fleet_state_visualizer/QUALITY_DECLARATION.md
@@ -1,0 +1,164 @@
+This document is a declaration of software quality for the `fleet_state_visualizer` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `fleet_state_visualizer` Quality Declaration
+
+The package `fleet_state_visualizer` claims to be in the **Quality Level 4** category.
+
+Below are the detailed rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`fleet_state_visualizer` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`fleet_state_visualizer` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+`fleet_state_visualizer` does not have a public API.
+
+### API Stability Policy [1.iv]
+
+`fleet_state_visualizer` does not have a public API.
+
+### ABI Stability Policy [1.v]
+
+`fleet_state_visualizer` does not have a public API.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`fleet_state_visualizer` does not have a public API.
+
+## Change Control Process [2]
+
+`fleet_state_visualizer` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`fleet_state_visualizer` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`fleet_state_visualizer` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+The CI checks only that the package builds.
+The most recent CI results can be seen on [the workflow page](https://github.com/osrf/rmf_schedule_visualizer/actions).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`fleet_state_visualizer` is documented in the [parent repository's README.md file](https://github.com/osrf/rmf_schedule_visualizer/blob/master/README.md).
+
+### Public API Documentation [3.ii]
+
+`fleet_state_visualizer` does not have a public API.
+
+### License [3.iii]
+
+The license for `fleet_state_visualizer` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+### Copyright Statement [3.iv]
+
+The copyright holders each provide a statement of copyright in each source code file in `fleet_state_visualizer`.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 4 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`fleet_state_visualizer` does not have any tests.
+
+### Public API Testing [4.ii]
+
+`fleet_state_visualizer` does not have a public API.
+
+### Coverage [4.iii]
+
+`fleet_state_visualizer` does not track coverage statistics.
+
+### Performance [4.iv]
+
+`fleet_state_visualizer` does not have performance tests.
+
+### Linters and Static Analysis [4.v]
+
+`fleet_state_visualizer` does not use any linters.
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`fleet_state_visualizer` has the following direct runtime ROS dependencies.
+
+#### rmf_fleet_msgs
+
+`rmf_fleet_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_fleet_msgs/QUALITY_DECLARATION.md).
+
+#### visualization_msgs
+
+`visualization_msgs` is [**Quality Level 3**](https://github.com/ros2/common_interfaces/blob/master/visualization_msgs/QUALITY_DECLARATION.md).
+
+#### rclpy
+
+`rclpy` does not declare a quality level.
+It is assumed to be **Quality Level 3** based on its wide-spread use, use of change control, use of CI, and use of testing.
+
+#### std_msgs
+
+`std_msgs` is [**Quality Level 3**](https://github.com/ros2/common_interfaces/blob/master/std_msgs/QUALITY_DECLARATION.md).
+
+#### rmf_traffic_msgs
+
+`rmf_traffic_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_traffic_msgs/QUALITY_DECLARATION.md).
+
+#### ament_index_python
+
+`ament_index_python` is [**Quality Level 4**](https://github.com/ament/ament_index/blob/master/ament_index_python/QUALITY_DECLARATION.md).
+
+#### building_map_msgs
+
+`building_map_msgs` is [**Quality Level 3**](https://github.com/osrf/traffic_editor/blob/master/building_map_msgs/QUALITY_DECLARATION.md).
+
+#### rmf_schedule_visualizer_msgs
+
+`rmf_schedule_visualizer_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_state_visualizer/blob/master/rmf_schedule_visualizer_msgs/QUALITY_DECLARATION.md).
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`fleet_state_visualizer` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`fleet_state_visualizer` does not have any direct runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+`fleet_state_visualizer` does not support all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers).
+`fleet_state_visualizer` supports ROS Eloquent and ROS Foxy.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/fleet_state_visualizer/README.md
+++ b/fleet_state_visualizer/README.md
@@ -1,0 +1,7 @@
+# fleet\_state\_visualizer
+
+This package provides visualisations for fleet states.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.

--- a/fleet_state_visualizer/fleet_state_visualizer/fleet_state_visualizer.py
+++ b/fleet_state_visualizer/fleet_state_visualizer/fleet_state_visualizer.py
@@ -1,3 +1,17 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import math
 import argparse
 import sys

--- a/rmf_schedule_visualizer/QUALITY_DECLARATION.md
+++ b/rmf_schedule_visualizer/QUALITY_DECLARATION.md
@@ -1,0 +1,184 @@
+This document is a declaration of software quality for the `rmf_schedule_visualizer` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_schedule_visualizer` Quality Declaration
+
+The package `rmf_schedule_visualizer` claims to be in the **Quality Level 4** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_schedule_visualizer` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_schedule_visualizer` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+All symbols in the installed headers are considered part of the public API.
+
+All installed headers are in the `include` directory of the package.
+Headers in any other folders are not installed and are considered private.
+
+### API Stability Policy [1.iv]
+
+`rmf_schedule_visualizer` will not break public API within a major version number.
+
+### ABI Stability Policy [1.v]
+
+`rmf_schedule_visualizer` will not break public ABI within a major version number.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`rmf_schedule_visualizer` will not break public API or ABI within a released ROS distribution, i.e. no major releases into the same ROS distribution once that ROS distribution is released.
+
+## Change Control Process [2]
+
+`rmf_schedule_visualizer` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_schedule_visualizer` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_schedule_visualizer` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+
+The most recent CI results can be seen on [the workflow page](https://github.com/osrf/rmf_core/actions?query=workflow%3Abuild+branch%3Amaster).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_schedule_visualizer` does not provide documentation.
+
+### Public API Documentation [3.ii]
+
+`rmf_schedule_visualizer` does not document its public API.
+
+### License [3.iii]
+
+The license for `rmf_schedule_visualizer` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+### Copyright Statement [3.iv]
+
+The copyright holders each provide a statement of copyright in each source code file in `rmf_schedule_visualizer`.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 4 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`rmf_schedule_visualizer` does not have tests.
+
+### Public API Testing [4.ii]
+
+`rmf_schedule_visualizer` does not have tests.
+
+### Coverage [4.iii]
+
+`rmf_schedule_visualizer` does not track coverage statistics.
+
+### Performance [4.iv]
+
+`rmf_schedule_visualizer` does not test performance.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_schedule_visualizer` uses the standard linters and static analysis tools for its CMake code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+Below are the required direct runtime ROS dependencies of `rmf_schedule_visualizer` and their evaluations.
+
+#### rmf_traffic
+
+`rmf_traffic` is [**Quality Level 4**](https://github.com/osrf/rmf_core/blob/master/rmf_traffic/QUALITY_DECLARATION.md).
+
+#### rmf_traffic_ros2
+
+`rmf_traffic_ros2` is [**Quality Level 4**](https://github.com/osrf/rmf_core/blob/master/rmf_traffic_ros2/QUALITY_DECLARATION.md).
+
+#### rmf_traffic_msgs
+
+`rmf_traffic_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_traffic_msgs/QUALITY_DECLARATION.md).
+
+#### rclcpp
+
+`rclcpp` is [**Quality Level 3**](https://github.com/ros2/rclcpp/blob/master/rclcpp/QUALITY_DECLARATION.md).
+
+#### geometry_msgs
+
+`geometry_msgs` is [**Quality Level 3**](https://github.com/ros2/common_interfaces/blob/master/geometry_msgs/QUALITY_DECLARATION.md).
+
+#### visualization_msgs
+
+`visualization_msgs` is [**Quality Level 3**](https://github.com/ros2/common_interfaces/blob/master/visualization_msgs/QUALITY_DECLARATION.md).
+
+#### rmf_schedule_visualizer_msgs
+
+`rmf_schedule_visualizer_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_state_visualizer/blob/master/rmf_schedule_visualizer_msgs/QUALITY_DECLARATION.md).
+
+#### building_map_msgs
+
+`building_map_msgs` is [**Quality Level 3**](https://github.com/osrf/traffic_editor/blob/master/building_map_msgs/QUALITY_DECLARATION.md).
+
+#### builtin_interfaces
+
+`builtin_interfaces` is [**Quality Level 3**](https://github.com/ros2/rcl_interfaces/blob/master/builtin_interfaces/QUALITY_DECLARATION.md).
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_schedule_visualizer` has no optional runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+Below are the required direct runtime non-ROS dependencies of `rmf_schedule_visualizer` and their evaluations.
+
+#### boost
+
+`boost` is assumed to be **Quality Level 3** due to its wide-spread use, history, use of CI, and use of testing.
+
+#### eigen
+
+`eigen` is assumed to be **Quality Level 3** due to its wide-spread use, history, use of CI, and use of testing.
+
+#### WebSocket++
+
+`WebSocket++` is assumed to be **Quality Level 3** due to its use of CI and use of testing.
+
+## Platform Support [6]
+
+### Target platforms [6.i]
+
+`rmf_schedule_visualizer` does not support all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers).
+`rmf_schedule_visualizer` supports ROS Eloquent.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_schedule_visualizer/README.md
+++ b/rmf_schedule_visualizer/README.md
@@ -1,0 +1,7 @@
+# fleet\_state\_visualizer
+
+This package provides a visualizer for trajectories in RMF schedules.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.

--- a/rmf_schedule_visualizer/include/rmf_schedule_visualizer/CommonData.hpp
+++ b/rmf_schedule_visualizer/include/rmf_schedule_visualizer/CommonData.hpp
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
 #ifndef RMF_SCHEDULE_VISUALIZER__COMMONDATA_HPP
 #define RMF_SCHEDULE_VISUALIZER__COMMONDATA_HPP
 

--- a/rmf_schedule_visualizer_msgs/QUALITY_DECLARATION.md
+++ b/rmf_schedule_visualizer_msgs/QUALITY_DECLARATION.md
@@ -1,0 +1,130 @@
+This document is a declaration of software quality for the `rmf_schedule_visualizer_msgs` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_schedule_visualizer_msgs` Quality Declaration
+
+The package `rmf_schedule_visualizer_msgs` claims to be in the **Quality Level 3** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_schedule_visualizer_msgs` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_schedule_visualizer_msgs` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+All message definition files located the `msg` directory are considered part of the public API.
+
+### API Stability Within a Released ROS Distribution [1.iv]/[1.vi]
+
+`rmf_schedule_visualizer_msgs` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
+
+### ABI Stability Within a Released ROS Distribution [1.v]/[1.vi]
+
+`rmf_schedule_visualizer_msgs` does not contain any C or C++ code and therefore will not affect ABI stability.
+
+## Change Control Process [2]
+
+`rmf_schedule_visualizer_msgs` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_schedule_visualizer_msgs` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_schedule_visualizer_msgs` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_schedule_visualizer_msgs` does not provide feature documentation.
+
+### Public API Documentation [3.ii]
+
+`rmf_schedule_visualizer_msgs` does not provide API documentation.
+
+### License [3.iii]
+
+The license for `rmf_schedule_visualizer_msgs` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+There are no source files that are currently copyrighted in this package so files are not checked for abbreviated license statements.
+
+### Copyright Statement [3.iv]
+
+There are no copyrighted source files in this package.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 3 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`rmf_schedule_visualizer_msgs` is a package providing strictly message and service definitions and therefore does not require associated tests.
+
+### Public API Testing [4.ii]
+
+`rmf_schedule_visualizer_msgs` is a package providing strictly message and service definitions and therefore does not require associated tests.
+
+### Coverage [4.iii]
+
+`rmf_schedule_visualizer_msgs` is a package providing strictly message and service definitions and therefore has no coverage requirements.
+
+### Performance [4.iv]
+
+`rmf_schedule_visualizer_msgs` is a package providing strictly message and service definitions and therefore has no performance requirements.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_schedule_visualizer_msgs` does not use the standard linters and static analysis tools for its generated C++ and Python code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`rmf_schedule_visualizer_msgs` has the following runtime ROS dependencies, which are at or above Quality Level 3:
+* `builtin_interfaces`: [QL 3](https://github.com/ros2/rcl_interfaces/tree/master/builtin_interfaces/QUALITY_DECLARATION.md)
+* `rosidl_default_runtime` [QL 3](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
+
+It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_schedule_visualizer_msgs` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rmf_schedule_visualizer_msgs` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+As a pure message and service definitions package, `rmf_schedule_visualizer_msgs` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), but does not currently test each change against all of them.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_schedule_visualizer_msgs/README.md
+++ b/rmf_schedule_visualizer_msgs/README.md
@@ -1,0 +1,9 @@
+# rmf\_schedule\_visualizer\_msgs
+
+`rmf_schedule_visualizer_msgs` provides message types for rviz parameters.
+
+For more information about ROS 2 interfaces, see [index.ros2.org](https://index.ros.org/doc/ros2/Concepts/About-ROS-Interfaces/)
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 3** category. See the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/rviz2_plugin/QUALITY_DECLARATION.md
+++ b/rviz2_plugin/QUALITY_DECLARATION.md
@@ -1,0 +1,200 @@
+This document is a declaration of software quality for the `rviz2_plugin` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rviz2_plugin` Quality Declaration
+
+The package `rviz2_plugin` claims to be in the **Quality Level 4** category.
+
+Below are the detailed rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rviz2_plugin` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rviz2_plugin` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+`rviz2_plugin` does not have a public API.
+
+### API Stability Policy [1.iv]
+
+`rviz2_plugin` does not have a public API.
+
+### ABI Stability Policy [1.v]
+
+`rviz2_plugin` does not have a public API.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`rviz2_plugin` does not have a public API.
+
+## Change Control Process [2]
+
+`rviz2_plugin` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rviz2_plugin` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rviz2_plugin` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+The CI checks only that the package builds.
+The most recent CI results can be seen on [the workflow page](https://github.com/osrf/rmf_schedule_visualizer/actions).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rviz2_plugin` is documented in the [parent repository's README.md file](https://github.com/osrf/rmf_schedule_visualizer/blob/master/README.md).
+
+### Public API Documentation [3.ii]
+
+`rviz2_plugin` does not have a public API.
+
+### License [3.iii]
+
+The license for `rviz2_plugin` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+### Copyright Statement [3.iv]
+
+The copyright holders each provide a statement of copyright in each source code file in `rmf_demo_tasks`.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 4 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`rviz2_plugin` does not have any tests.
+
+### Public API Testing [4.ii]
+
+`rviz2_plugin` does not have a public API.
+
+### Coverage [4.iii]
+
+`rviz2_plugin` does not track coverage statistics.
+
+### Performance [4.iv]
+
+`rviz2_plugin` does not have performance tests.
+
+### Linters and Static Analysis [4.v]
+
+`rviz2_plugin` does not use the standard linters and static analysis tools for its CMake code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`rviz2_plugin` has the following direct runtime ROS dependencies.
+
+#### rclcpp
+
+`rclcpp` is [**Quality Level 3**](https://github.com/ros2/rclcpp/blob/master/rclcpp/QUALITY_DECLARATION.md).
+
+#### rmf\_door\_msgs
+
+`rmf_door_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_door_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_lift\_msgs
+
+`rmf_lift_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_lift_msgs/QUALITY_DECLARATION.md).
+
+#### rmf_schedule_visualizer_msgs
+
+`rmf_schedule_visualizer_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_state_visualizer/blob/master/rmf_schedule_visualizer_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_traffic\_ros2
+
+`rmf_traffic_ros2` is [**Quality Level 4**](https://github.com/osrf/rmf_core/blob/master/rmf_traffic_ros2/QUALITY_DECLARATION.md).
+
+#### rviz\_common
+
+`rviz_common` does not declare a Quality Level.
+It is assumed to be at **Quality Level 4** based on its widespread use.
+
+#### rviz\_default\_plugins
+
+`rviz_default_plugins` does not declare a Quality Level.
+It is assumed to be at **Quality Level 4** based on its widespread use.
+
+#### rviz\_rendering
+
+`rviz_rendering` does not declare a Quality Level.
+It is assumed to be at **Quality Level 4** based on its widespread use.
+
+#### pluginlib
+
+`pluginlib` does not declare a Quality Level.
+It is assumed to be at **Quality Level 4** based on its widespread use.
+
+#### resource_retriever
+
+`resource_retriever` does not declare a Quality Level.
+It is assumed to be at **Quality Level 4** based on its widespread use.
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rviz2_plugin` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rviz2_plugin` has the following runtime non-ROS dependencies.
+
+#### qtbase5-dev
+
+`qtbase5-dev` is widely-used third-party software for building graphical applications.
+Due to its wide use, documentation, and testing, it is assumed to be **Quality Level 3**.
+
+#### libqt5-core
+
+`libqt5-core` is widely-used third-party software for building graphical applications.
+Due to its wide use, documentation, and testing, it is assumed to be **Quality Level 3**.
+
+#### libqt5-gui
+
+`libqt5-gui` is widely-used third-party software for building graphical applications.
+Due to its wide use, documentation, and testing, it is assumed to be **Quality Level 3**.
+
+#### libqt5-widgets
+
+`libqt5-widgets` is widely-used third-party software for building graphical applications.
+Due to its wide use, documentation, and testing, it is assumed to be **Quality Level 3**.
+
+#### eigen
+
+`eigen` is assumed to be **Quality Level 3** due to its wide-spread use, history, use of CI, and use of testing.
+
+## Platform Support [6]
+
+`rviz2_plugin` does not support all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers).
+`rviz2_plugin` supports ROS Eloquent and ROS Foxy.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rviz2_plugin/README.md
+++ b/rviz2_plugin/README.md
@@ -1,0 +1,7 @@
+# rviz2\_plugin
+
+This package provides panel plugins for `rviz` to control building infrastructure and schedules.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.

--- a/visualizer/QUALITY_DECLARATION.md
+++ b/visualizer/QUALITY_DECLARATION.md
@@ -1,0 +1,154 @@
+This document is a declaration of software quality for the `visualizer` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `visualizer` Quality Declaration
+
+The package `visualizer` claims to be in the **Quality Level 4** category.
+The main rationale for this claim its its status as a collection of demonstration launch files.
+
+Below are the detailed rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`visualizer` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`visualizer` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+All launch files in the installed `launch` directory are considered part of the public API.
+
+### API Stability Policy [1.iv]
+
+`visualizer` will not break public API within a major version number.
+
+### ABI Stability Policy [1.v]
+
+`visualizer` does not have a public ABI.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`visualizer` will not break public API or ABI within a released ROS distribution, i.e. no major releases into the same ROS distribution once that ROS distribution is released.
+
+## Change Control Process [2]
+
+`visualizer` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`visualizer` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`visualizer` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+The CI checks only that the package builds.
+The most recent CI results can be seen on [the workflow page](https://github.com/osrf/rmf_schedule_visualizer/actions).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`visualizer` is documented in the [parent repository's README.md file](https://github.com/osrf/rmf_schedule_visualizer/blob/master/README.md).
+
+### Public API Documentation [3.ii]
+
+`visualizer` does not have documentation for its public API.
+
+### License [3.iii]
+
+The license for `visualizer` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+There are no source files that are currently copyrighted in this package so files are not checked for abbreviated license statements.
+
+### Copyright Statement [3.iv]
+
+There are no copyrighted source files in this package.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 3 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`visualizer` is a package providing strictly launch files and therefore does not require associated tests.
+
+### Public API Testing [4.ii]
+
+`visualizer` is a package providing strictly launch files and therefore does not require associated tests.
+
+### Coverage [4.iii]
+
+`visualizer` is a package providing strictly launch files and therefore does not require associated tests.
+
+### Performance [4.iv]
+
+`visualizer` is a package providing strictly launch files and therefore does not require associated tests.
+
+### Linters and Static Analysis [4.v]
+
+`visualizer` does not use the [standard linters and static analysis tools](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`visualizer` has the following runtime ROS dependencies.
+
+#### rmf_schedule_visualizer
+
+`rmf_schedule_visualizer` is [**Quality Level 3**](https://github.com/osrf/rmf_state_visualizer/blob/master/rmf_schedule_visualizer/QUALITY_DECLARATION.md).
+
+#### fleet_state_visualizer
+
+`fleet_state_visualizer` is [**Quality Level 3**](https://github.com/osrf/rmf_state_visualizer/blob/master/fleet_state_visualizer/QUALITY_DECLARATION.md).
+
+#### building_systems_visualizer
+
+`building_systems_visualizer` is [**Quality Level 3**](https://github.com/osrf/rmf_state_visualizer/blob/master/building_systems_visualizer/QUALITY_DECLARATION.md).
+
+#### rviz2_plugin
+
+`rviz2_plugin` is [**Quality Level 4**](https://github.com/osrf/rmf_state_visualizer/blob/master/rviz2_plugin/QUALITY_DECLARATION.md).
+
+#### launch_xml
+
+`launch_xml` does not declare a Quality Level.
+It is assumed tobe at **Quality Level 4** based on its widespread use.
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`visualizer` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`visualizer` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+As a pure message and service definitions package, `visualizer` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), but does not currently test each change against all of them.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/visualizer/README.md
+++ b/visualizer/README.md
@@ -1,0 +1,7 @@
+# demos
+
+This package provides launch files for launching the RMF visualisations.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.


### PR DESCRIPTION
This PR adds [quality declaration documents](https://www.ros.org/reps/rep-2004.html) and (where necessary) basic README files too all packages in `rmf_schedule_visualizer`.

The message packages meet the requirements to be Quality Level 3. All source-code-containing packages are currently QL4.

We need to go over each declaration and discuss it, making sure we all agree on the arguments being made.

Once this PR goes in, we can make a list of tasks that need to be done to move the packages up to higher quality levels.