### PR TITLE
set all versions to 1.1.0

### DIFF
--- a/rmf_schedule_visualizer_msgs/package.xml
+++ b/rmf_schedule_visualizer_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_schedule_visualizer_msgs</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <description>A package containing messages used by rmf_schedule_visualizer</description>
   <maintainer email="yadunund@openrobotics.org">yadu</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
All versions need to be the same in order to be released under 1.1.0. For now on we will:

- Set all packages version to the highest version
- Include only the version info in the changelogs of those packages that actually have something new